### PR TITLE
Cleanup patterns

### DIFF
--- a/patterns/base/a/pattern.yml
+++ b/patterns/base/a/pattern.yml
@@ -1,5 +1,5 @@
 name: Anchor link
-description: Anchor link
+description: Tag to define a hyperlink
 displayTemplate: pattern
 applicationMethods:
   - code: '.base--a'

--- a/patterns/base/body/README.md
+++ b/patterns/base/body/README.md
@@ -1,1 +1,1 @@
-The `<body>`tag defines the document's body, which contains all of its content.
+The `<body>` tag defines the body of the document, which contains all of its content.

--- a/patterns/base/body/pattern.yml
+++ b/patterns/base/body/pattern.yml
@@ -1,5 +1,5 @@
 name: Body
-description: The document's body which contains all of its content
+description: The body of the document which contains all of its content
 displayTemplate: pattern
 applicationMethods:
   - code: body
@@ -8,10 +8,10 @@ settings:
   - setting: sans serif font
     description: Font family for site
   - setting: light weight font
-    description: Font weight for light weight fonts. Used as default for whole site
+    description: Font weight for light weight fonts. Used as default for whole site.
   - setting: rhythm
     description: Vertical rhythm of items (`margin-top`)
-  - setting: backgronud color
+  - setting: background color
     description: Color of site's background
   - setting: text color
     description: Color of site's main body text

--- a/patterns/base/ol/pattern.yml
+++ b/patterns/base/ol/pattern.yml
@@ -12,7 +12,7 @@ variables:
   listitems:
     - List item 1
     - List item 2
-    - Really super duper long list item so we can see how lists look like when they wrap
+    - Really super duper long list item that is included so that we can see what lists look like when they wrap
     - List item 3
     - List item 4
     - List item 5

--- a/patterns/base/p/README.md
+++ b/patterns/base/p/README.md
@@ -1,1 +1,1 @@
-The paragraph element, '<p>', represents a longer section of text. Authors traditionally divide their thoughts and arguments into sequences of paragraphs.
+The paragraph element, `<p>`, represents a longer section of text. Authors traditionally divide their thoughts and arguments into sequences of paragraphs.

--- a/patterns/base/pre/README.md
+++ b/patterns/base/pre/README.md
@@ -1,1 +1,1 @@
-Pre formatted text, `<pre>`, is an example of text that whose whitespace is preserved. It is most often used with a nested `<code>` tag to display code blocks
+Pre formatted text, `<pre>`, is an example of text in which the whitespace is preserved. It is most often used with a nested `<code>` tag to display code blocks.

--- a/patterns/base/select/pattern.yml
+++ b/patterns/base/select/pattern.yml
@@ -1,5 +1,5 @@
 name: Select Box
-description: A flexible and configurable way of selecting an indivdual item from a list
+description: A flexible and configurable way of selecting an individual item from a list
 displayTemplate: pattern
 applicationMethods:
   - code: '.base--select'

--- a/patterns/base/ul/pattern.yml
+++ b/patterns/base/ul/pattern.yml
@@ -12,5 +12,5 @@ variables:
   listitems:
     - List item 1
     - List item 2
-    - Really super duper long list item so we can see how lists look like when they wrap
+    - Really super duper long list item that is included so that we can see what lists look like when they wrap
     - List item 3

--- a/patterns/components/loading-indicator/README.md
+++ b/patterns/components/loading-indicator/README.md
@@ -1,8 +1,8 @@
 The loading indicator should be used whenever Watson is processing information.
 
 ## SVG Animations
-SVG and Gif fallback animations are housed in the `images` folder
+SVG and Gif fallback animations are housed in the `images` folder.
 
-- All of the Animation is housed within the SVG file. There are 2 types of animation in the SVG file:
-  - `SMIL`- Animates the smaller elements like strokes and dots animating 
-  - `CSS` - Animate the larger elements like scaling of the entire SVG
+- All of the animation is stored in the SVG file. There are 2 types of animations in the SVG file:
+  - `SMIL`- Animates the smaller elements, like strokes and dots animating 
+  - `CSS` - Animates the larger elements, like scaling the entire SVG

--- a/patterns/components/loading-indicator/pattern.yml
+++ b/patterns/components/loading-indicator/pattern.yml
@@ -1,5 +1,5 @@
 name: Loading Indicator
-description: A loader for when Watson is thinking.
+description: A loader for when Watson is thinking
 displayTemplate: pattern
 applicationMethods:
   - code: 'loading-indicator.svg'


### PR DESCRIPTION
Resolves #293 

CHANGELOG
:bug: Fix typo
:bug: Change description for anchor link
:bug: Update description and typos for Body pattern
:bug: Add space and reword README for Body pattern
:bug: Extend super duper long list item so that it actually wraps
:bug: Change apostrophes to backticks
:bug: Remove redundant words in Pre pattern README
:bug: Extend super duper long list item so that it actually wraps
:bug: Remove period in description
:bug: Update README for Loading Indicator