### PR TITLE
Fix Front Matter for Peformance Example Video

### DIFF
--- a/language/02-guidelines/user-experience/performance/index.md
+++ b/language/02-guidelines/user-experience/performance/index.md
@@ -18,7 +18,7 @@ resources:
     - name: "Web Page Test"
       source: http://www.webpagetest.org/
 variables:
-  detail:
+  example:
     framesPerSecond:
       visualDisplay: /videos/performance/performance2.webm
       title: "FPS/Hertz Comparison"


### PR DESCRIPTION
:bug: fixing front matter for the video is rendered as an `example` not adopting styling for `detail`