### PR TITLE
Make example description appear as caption

### DIFF
--- a/library/sass/components/_example.scss
+++ b/library/sass/components/_example.scss
@@ -5,6 +5,13 @@
   }
 }
 
+[library-class='example--SMALL'] {
+  [library-class='example--description'] {
+    font-size: .8em;
+  }
+}
+
+
 [library-class='example--title'] {
   @extend %base--strong;
 }


### PR DESCRIPTION
Resolves ibm-watson/design-library#325