### PR TITLE
Remove settings column when there are no settings to display

### DIFF
--- a/library/templates/_pattern.html
+++ b/library/templates/_pattern.html
@@ -19,6 +19,7 @@
       {% endfor %}
     </ul>
   </aside>
+  {% if pattern.metadata.settings %}
   <aside library-class="pattern--settings">
     <header library-class="pattern--header" class="base--h3">
       <h3>Settings</h3>
@@ -28,7 +29,8 @@
       <li class="base--li"><code class="base--code">{{ setting.setting }}</code> - <span library-class="pattern--inline-description" class="base--STYLED">{{ setting.description|markdown | safe -}}</span></li>
       {% endfor %}
     </ul>
-</aside>
+  </aside>
+  {% endif %}
 </article>
 
 


### PR DESCRIPTION
Resolves #409 

CHANGELOG
:bug: Remove settings column when there are no settings to display

`DCO 1.1 Signed-off-by: Robyn Hammond <rlhammon@us.ibm.com>`